### PR TITLE
Improve leadwise layout generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,7 @@ dependencies = [
  "itertools",
  "log 0.3.9",
  "monument",
+ "ordered-float",
  "pretty_logger",
  "serde",
  "structopt",
@@ -697,6 +698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97c9d06878b3a851e8026ef94bf7fef9ba93062cd412601da4d9cf369b1cc62d"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/bellframe/src/row/borrowed.rs
+++ b/bellframe/src/row/borrowed.rs
@@ -533,6 +533,10 @@ impl Row {
 
     /* MISC FUNCTIONS */
 
+    pub fn is_fixed(&self, bell: Bell) -> bool {
+        self.bell_slice.get(bell.index()) == Some(&bell)
+    }
+
     /// Returns an [`Iterator`] over the [`Bell`]s in this `Row` which are fixed in their home
     /// positions (i.e. they're fixed by the transposition represented by this row).
     pub fn fixed_bells(&self) -> impl Iterator<Item = Bell> + '_ {

--- a/monument/cli/Cargo.toml
+++ b/monument/cli/Cargo.toml
@@ -16,6 +16,7 @@ toml = "0.5"
 [dev-dependencies]
 colored = "2.0"
 difference = "2.0"
+ordered-float = { version = "2.8", features = ["serde"] }
 
 [[test]]
 name = "integration"

--- a/monument/cli/src/calls.rs
+++ b/monument/cli/src/calls.rs
@@ -99,7 +99,7 @@ pub struct SpecificCall {
 }
 
 impl SpecificCall {
-    fn to_call_spec(&self, stage: Stage) -> Result<Call, Error> {
+    pub(crate) fn to_call_spec(&self, stage: Stage) -> Result<Call, Error> {
         Ok(Call::new(
             self.symbol.clone(),
             self.debug_symbol.as_ref().unwrap_or(&self.symbol).clone(),
@@ -110,20 +110,6 @@ impl SpecificCall {
             self.weight,
         ))
     }
-}
-
-pub fn gen_calls(
-    stage: Stage,
-    base_calls: BaseCalls,
-    bob_weight: Option<f32>,
-    single_weight: Option<f32>,
-    calls: &[SpecificCall],
-) -> Result<Vec<Call>, Error> {
-    let mut call_specs = base_calls.to_call_specs(stage, bob_weight, single_weight);
-    for specific_call in calls {
-        call_specs.push(specific_call.to_call_spec(stage)?);
-    }
-    Ok(call_specs)
 }
 
 #[inline(always)]

--- a/monument/cli/src/spec.rs
+++ b/monument/cli/src/spec.rs
@@ -6,19 +6,19 @@ use std::{
 
 use bellframe::{
     method::LABEL_LEAD_END, method_lib::QueryError, music::Regex, Bell, Mask, Method, MethodLib,
-    RowBuf, Stage,
+    Row, RowBuf, Stage,
 };
 use itertools::Itertools;
 use log::log;
 use monument::{
-    layout::new::{coursewise, leadwise, SpliceStyle},
+    layout::new::{coursewise, leadwise, Call, SpliceStyle},
     music::MusicType,
     OptRange, Query,
 };
 use serde::Deserialize;
 
 use crate::{
-    calls::{gen_calls, BaseCalls, SpecificCall},
+    calls::{BaseCalls, SpecificCall},
     Error,
 };
 
@@ -45,8 +45,10 @@ pub struct Spec {
     part_head: Option<String>,
     /// If `true`, generate compositions lead-wise, rather than course-wise.  This is useful for
     /// cases like cyclic comps where no course heads are preserved across parts.
-    #[serde(default)]
-    leadwise: bool,
+    ///
+    /// If left unset, Monument will determine the best value - i.e. leadwise iff the part head
+    /// affects the tenor
+    leadwise: Option<bool>,
 
     /// Set to `true` to allow comps to not start at the lead head.
     #[serde(default)]
@@ -117,15 +119,70 @@ impl Spec {
             methods.push(m.gen_method()?);
         }
 
-        // Stage & tenor
         let stage = methods
             .iter()
             .map(|(m, _)| m.stage())
             .max()
             .ok_or(Error::NoMethods)?;
-        let tenor = Bell::tenor(stage);
 
-        // Music
+        let part_head = match &self.part_head {
+            Some(ph) => RowBuf::parse_with_stage(ph, stage).map_err(Error::PartHeadParse)?,
+            None => RowBuf::rounds(stage),
+        };
+
+        let (start_indices, end_indices) = self.start_end_indices(&part_head);
+        let start_indices = start_indices.as_deref();
+        let end_indices = end_indices.as_deref();
+
+        let course_head_masks = self.course_head_masks(stage);
+
+        let leadwise = self.leadwise.unwrap_or_else(|| {
+            // Set 'coursewise' as the default iff the part head doesn't preserve the positions of
+            // all fixed bells
+            !course_head_masks
+                .iter()
+                .all(|(_mask, calling_bell)| part_head.is_fixed(*calling_bell))
+        });
+
+        // Generate a `Layout` from the data about the method and calls
+        let calls = self.calls(stage)?;
+        let layout = if leadwise {
+            leadwise::leadwise(&methods, &calls, start_indices, end_indices)
+        } else {
+            coursewise::coursewise(
+                &methods,
+                &calls,
+                self.splice_style,
+                course_head_masks,
+                start_indices,
+                end_indices,
+            )
+        }
+        .map_err(Error::LayoutGen)?;
+
+        let music_types = self.music_types(toml_path, stage)?;
+        if music_types.is_empty() {
+            // TODO: Add default music
+            log::warn!("No music patterns specified.  Are you sure you don't care about music?");
+        }
+
+        let method_count_range =
+            method_count_range(methods.len(), &self.length.range, self.method_count);
+        log::info!("Method count range: {:?}", method_count_range);
+        // Build this layout into a `Graph`
+        Ok(Query {
+            layout,
+            part_head,
+            len_range: self.length.range.clone(),
+            num_comps: self.num_comps,
+
+            method_count_range,
+            music_types,
+            max_duffer_rows: self.max_duffer_rows,
+        })
+    }
+
+    fn music_types(&self, toml_path: &Path, stage: Stage) -> Result<Vec<MusicType>, Error> {
         let mut music_types = self
             .music
             .iter()
@@ -150,13 +207,22 @@ impl Spec {
                     .flat_map(|spec| spec.to_music_types(stage, self.default_non_duffer)),
             );
         }
+        Ok(music_types)
+    }
 
-        if music_types.is_empty() {
-            log::warn!("No music patterns specified.  Are you sure you don't care about music?");
+    fn calls(&self, stage: Stage) -> Result<Vec<Call>, Error> {
+        let mut call_specs =
+            self.base_calls
+                .to_call_specs(stage, self.bob_weight, self.single_weight);
+        for specific_call in &self.calls {
+            call_specs.push(specific_call.to_call_spec(stage)?);
         }
+        Ok(call_specs)
+    }
 
-        // CH masks
-        let course_head_masks = if let Some(ch_mask_strings) = &self.course_heads {
+    fn course_head_masks(&self, stage: Stage) -> Vec<(Mask, Bell)> {
+        let tenor = Bell::tenor(stage);
+        if let Some(ch_mask_strings) = &self.course_heads {
             // If masks are specified, parse all the course head mask strings into `Mask`s,
             // defaulting to the tenor as calling bell
             ch_mask_strings
@@ -170,89 +236,48 @@ impl Spec {
         } else {
             // Default to tenors together, with the tenor as 'calling bell'
             vec![(tenors_together_mask(stage), tenor)]
-        };
+        }
+    }
 
-        // Calls
-        let calls = gen_calls(
-            stage,
-            self.base_calls,
-            self.bob_weight,
-            self.single_weight,
-            &self.calls,
-        )?;
-
-        // Data external to the `Layout`
-        let method_count_range =
-            method_count_range(methods.len(), &self.length.range, self.method_count);
-        log::info!("Method count range: {:?}", method_count_range);
-        let part_head = match &self.part_head {
-            Some(ph) => RowBuf::parse_with_stage(ph, stage).map_err(Error::PartHeadParse)?,
-            None => RowBuf::rounds(stage),
-        };
-
-        // Compute the start/end indices.
+    fn start_end_indices(&self, part_head: &Row) -> (Option<Vec<usize>>, Option<Vec<usize>>) {
         let mut start_indices = if self.snap_start {
             None
         } else {
-            self.start_indices.as_deref()
+            self.start_indices.clone()
         };
-        let mut end_indices = self.end_indices.as_deref();
+        let mut end_indices = self.end_indices.clone();
 
-        // If this is a multi-part, then we require that
-        // `start_indices` and `end_indices` must specify the same set of nodes.
+        // If this is a multi-part, then we require that `start_indices` and `end_indices` must be
+        // the same.
         //
-        // TODO: This is not quite correct; more specifically, we need to create separate graphs
+        // TODO: This is not quite correct.  More specifically, we need to create separate graphs
         // for each of the possible start/end indices.  This is because most of Monument can't tell
         // the difference between multi- and single-part comps, and therefore assumes that any pair
         // of starts/finishes are allowed.  In a multi-part this is not true, because we really
         // want the part-head to randomly cause a lead to re-start.  For the time being, we just
-        // panic if we'd generate a multi-part graph with more than one node.
-        let mut union_vec = Vec::new();
+        // panic if we'd generate a multi-part graph with more than one start index.
         if !part_head.is_rounds() {
             let idx_union = match (start_indices, end_indices) {
                 (Some(starts), Some(ends)) => {
-                    // We put the contents into `union_vec` so that our output has type
-                    // `Option<&[usize]>`.  The lifetime of the output is tied to the outer
-                    // function scope, which is long enough to be used to generate the `Layout`
-                    union_vec.extend(starts.iter().copied().filter(|i| ends.contains(i)));
-                    Some(union_vec.as_slice())
+                    let union_vec = starts
+                        .iter()
+                        .copied()
+                        .filter(|i| ends.contains(i))
+                        .collect_vec();
+                    Some(union_vec)
                 }
                 (Some(idxs), None) | (None, Some(idxs)) => Some(idxs),
                 (None, None) => None,
             };
-            start_indices = idx_union;
-            end_indices = idx_union;
             // Check that we only have one start/end index.  If we don't, Monument will try to
             // mix-and-match, usually causing things like reaching part heads at the snap
-            assert!(idx_union.map_or(false, |idxs| idxs.len() == 1));
+            assert!(idx_union.as_ref().map_or(false, |idxs| idxs.len() == 1));
+            // Set both starts and ends to the same value
+            start_indices = idx_union.clone();
+            end_indices = idx_union;
         }
 
-        // Generate a `Layout` from the data about the method and calls
-        let layout = if self.leadwise {
-            leadwise::leadwise(&methods, &calls, start_indices, end_indices)
-        } else {
-            coursewise::coursewise(
-                &methods,
-                &calls,
-                self.splice_style,
-                course_head_masks,
-                start_indices,
-                end_indices,
-            )
-        }
-        .map_err(Error::LayoutGen)?;
-
-        // Build this layout into a `Graph`
-        Ok(Query {
-            layout,
-            part_head,
-            len_range: self.length.range.clone(),
-            num_comps: self.num_comps,
-
-            method_count_range,
-            music_types,
-            max_duffer_rows: self.max_duffer_rows,
-        })
+        (start_indices, end_indices)
     }
 }
 

--- a/monument/cli/src/spec.rs
+++ b/monument/cli/src/spec.rs
@@ -282,7 +282,7 @@ fn method_count_range(
     let max_f32 = len_range.end as f32 / num_methods as f32 * (1.0 + METHOD_BALANCE_ALLOWANCE);
     let min = user_range.min.unwrap_or(min_f32.floor() as usize);
     let max = user_range.max.unwrap_or(max_f32.ceil() as usize);
-    min..max
+    min..max + 1 // + 1 because the `method_count` is an **inclusive** range
 }
 
 /// Error generated when a user tries to read a TOML file from the FS

--- a/monument/cli/src/spec.rs
+++ b/monument/cli/src/spec.rs
@@ -347,7 +347,7 @@ impl MethodSpec {
         // Use the custom shorthand, or the first letter of the method's name, or "?" if the method
         // has no name
         let shorthand = self.shorthand().unwrap_or_else(|| {
-            m.name()
+            m.title()
                 .chars()
                 .next()
                 .map_or_else(|| "?".to_owned(), |c| c.to_string())

--- a/monument/lib/src/layout/new/leadwise.rs
+++ b/monument/lib/src/layout/new/leadwise.rs
@@ -74,7 +74,6 @@ fn start_or_ends<I: index_vec::Idx>(
             if row_idx != 0 {
                 label.push_str(snap_label);
             }
-
             StartOrEnd {
                 course_head: !row,
                 row_idx: RowIdx::new(block_idx, row_idx),
@@ -147,10 +146,9 @@ fn links(
         let ends = &call_ends[label];
 
         for start in starts {
+            let mut row_after_call = start.row_before.clone();
+            call.place_not.permute(&mut row_after_call).unwrap();
             for end in ends {
-                let mut row_after_call = start.row_before.clone();
-                call.place_not.permute(&mut row_after_call).unwrap();
-
                 // Call
                 links.push(Link {
                     from: start.row_idx,
@@ -163,25 +161,55 @@ fn links(
                     display_name: format!("[{}]", call.debug_symbol),
                     weight: call.weight,
                 });
-                // Plain lead
-                links.push(Link {
-                    from: start.row_idx,
-                    to: end.row_idx,
-
-                    ch_mask: lead_head_mask.clone(),
-                    ch_transposition: &start.row_after_plain * &end.inv_row,
-
-                    debug_name: "p".to_owned(),
-                    display_name: String::new(),
-                    weight: 0.0,
-                });
+                // Plain
+                links.push(plain_link(
+                    start.row_idx,
+                    end.row_idx,
+                    lead_head_mask,
+                    &start.row_after_plain * &end.inv_row,
+                ));
             }
+        }
+    }
+
+    // Always add plain links at the end of every lead.  In nearly all cases, these will already
+    // exist and be deduplicated, but if there are no calls at the end of each lead (e.g. in
+    // link-cyclic or Stedman) then these will have to be generated separately.
+    for (method_idx_from, (method_from, _)) in methods.iter().enumerate() {
+        for (method_idx_to, _) in methods.iter().enumerate() {
+            links.push(plain_link(
+                RowIdx {
+                    block: method_idx_from.into(),
+                    // - 1 to refer to the lead **end** not the lead **head**
+                    row: method_from.lead_len() - 1,
+                },
+                RowIdx {
+                    block: method_idx_to.into(),
+                    row: 0,
+                },
+                lead_head_mask,
+                method_from.lead_head().to_owned(),
+            ));
         }
     }
 
     // Deduplicate links and return
     super::dedup_links(&mut links);
     links.into()
+}
+
+fn plain_link(from: RowIdx, to: RowIdx, ch_mask: &Mask, ch_transposition: RowBuf) -> Link {
+    Link {
+        from,
+        to,
+
+        ch_mask: ch_mask.clone(),
+        ch_transposition,
+
+        debug_name: "p".to_owned(),
+        display_name: String::new(),
+        weight: 0.0,
+    }
 }
 
 /// A position at which a call could start

--- a/monument/lib/src/search/mod.rs
+++ b/monument/lib/src/search/mod.rs
@@ -151,7 +151,7 @@ pub(crate) fn search<CompFn: FnMut(Comp)>(
 
         // If the queue gets too long, then halve its size
         if frontier.len() >= queue_limit {
-            log::debug!("Truncating queue");
+            log::info!("Truncating queue");
             truncate_heap(&mut frontier, queue_limit / 2);
         }
 

--- a/monument/test/_results.toml
+++ b/monument/test/_results.toml
@@ -204,6 +204,46 @@ string = "sWsMMBsHHsHsMsWsMHsHH"
 length = 224
 string = ""
 
+[[little-bob-shorthand]]
+length = 48
+string = "LLLPL"
+
+[[little-bob-shorthand]]
+length = 56
+string = "LLLLLLL"
+
+[[little-bob-shorthand]]
+length = 112
+string = "PPPPPPP"
+
+[[little-bob-shorthand]]
+length = 48
+string = "LLLLP"
+
+[[little-bob-shorthand]]
+length = 48
+string = "LPLLL"
+
+[[little-bob-shorthand]]
+length = 48
+string = "LLPLL"
+
+[[little-bob-shorthand]]
+length = 40
+string = "LPP"
+
+[[little-bob-shorthand]]
+length = 48
+string = "PLLLL"
+
+[[little-bob-shorthand]]
+length = 40
+string = "PPL"
+
+[[little-bob-shorthand]]
+length = 40
+string = "PLP"
+
 [[multipart]]
 length = 192
 string = "HsHH"

--- a/monument/test/_results.toml
+++ b/monument/test/_results.toml
@@ -1,765 +1,1116 @@
 multipart-self-false = []
 
 [[bristol-s8-qps]]
+avg_score = 0.11079997569322586
 length = 1250
 string = "sWsHHsHBsHHHsHBsWsHBWW>"
 
 [[bristol-s8-qps]]
-length = 1280
-string = "WWHBsHHHsHHsMsWMH"
-
-[[bristol-s8-qps]]
-length = 1280
-string = "sWMsMMMBsHHsHsMsWMH"
-
-[[bristol-s8-qps]]
+avg_score = 0.11140622943639755
 length = 1280
 string = "WWHBHsHHHsHsMsWMH"
 
 [[bristol-s8-qps]]
+avg_score = 0.11140622943639755
+length = 1280
+string = "WWHBsHHHsHHsMsWMH"
+
+[[bristol-s8-qps]]
+avg_score = 0.11140622943639755
+length = 1280
+string = "sWMsMMMBsHHsHsMsWMH"
+
+[[bristol-s8-qps]]
+avg_score = 0.11143998056650162
 length = 1250
 string = "sWHHBHHsHsMsWWsHBWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11143998056650162
 length = 1250
 string = "sWHsHBsHHsHsMsWWsHBWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11143998056650162
 length = 1250
 string = "sWsMMBsHHsHsMsWWsHBWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11156247556209564
 length = 1280
 string = "sWHHBHHsHHBsHMMHsH"
 
 [[bristol-s8-qps]]
+avg_score = 0.11159997433423996
 length = 1250
 string = "sWHHBHHsHsMMBsWsHBWW>"
 
 [[bristol-s8-qps]]
-length = 1250
-string = "sWsMMBsHHsHsMMBsWsHBWW>"
-
-[[bristol-s8-qps]]
+avg_score = 0.11159997433423996
 length = 1250
 string = "sWHsHBsHHsHsMMBsWsHBWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11159997433423996
+length = 1250
+string = "sWsMMBsHHsHsMMBsWsHBWW>"
+
+[[bristol-s8-qps]]
+avg_score = 0.11234372854232788
 length = 1280
 string = "WWHBHsHHHsHBWsWsMH"
 
 [[bristol-s8-qps]]
+avg_score = 0.11234372854232788
 length = 1280
 string = "WWHBsHHHsHHBWsWsMH"
 
 [[bristol-s8-qps]]
+avg_score = 0.11234372854232788
 length = 1280
 string = "sWMsMMMBsHHsHBWsWsMH"
 
 [[bristol-s8-qps]]
+avg_score = 0.11239997297525406
 length = 1250
 string = "WHHBHsHHHBsWsHBsWWsW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11296872794628143
 length = 1280
 string = "sWsMMBHsHHHsHsMsWMH"
 
 [[bristol-s8-qps]]
+avg_score = 0.11296872794628143
 length = 1280
 string = "sWsMMBsHHHsHHsMsWMH"
 
 [[bristol-s8-qps]]
+avg_score = 0.11383996903896332
 length = 1250
 string = "BsMWHsMMMsMsWsHBsWWsW>"
 
 [[bristol-s8-qps]]
-length = 1280
-string = "sWsMMBsHHHsHHBWsWsMH"
-
-[[bristol-s8-qps]]
+avg_score = 0.11390622705221176
 length = 1280
 string = "sWsMMBHsHHHsHBWsWsMH"
 
 [[bristol-s8-qps]]
-length = 1250
-string = "sWsMMBHsHHHsHsWMWW>"
+avg_score = 0.11390622705221176
+length = 1280
+string = "sWsMMBsHHHsHHBWsWsMH"
 
 [[bristol-s8-qps]]
+avg_score = 0.11447998136281967
 length = 1250
 string = "sWHsHBHsHHHsHsWMWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11447998136281967
 length = 1250
 string = "sWHsHBsHHHsHHsWMWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11447998136281967
+length = 1250
+string = "sWsMMBHsHHHsHsWMWW>"
+
+[[bristol-s8-qps]]
+avg_score = 0.11447998136281967
 length = 1250
 string = "sWsMMBsHHHsHHsWMWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11479997634887695
 length = 1250
 string = "sWHsHBHHsHHHBsWsHBWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11479997634887695
 length = 1250
 string = "sWsMMBHHsHHHBsWsHBWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11531247943639755
 length = 1280
 string = "sWsMMBHHsMsWMsHHHsH"
 
 [[bristol-s8-qps]]
+avg_score = 0.11543998122215271
 length = 1250
 string = "sWWWHHBWHMBsHsMWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11623996496200562
 length = 1250
 string = "BsMsWWMsMsWsHBWsWWWsW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11623996496200562
 length = 1250
 string = "BsMsWWMsMsWsHBsWWWsWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11624997854232788
 length = 1280
 string = "sWsMMBHHBWsWsMsHHHsH"
 
 [[bristol-s8-qps]]
+avg_score = 0.11671998351812363
 length = 1250
 string = "sWWWHHsWsHMHMWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.11783997714519501
 length = 1250
 string = "sWWWHHBWHMsWsHBWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.1202399805188179
 length = 1250
 string = "BWHMsMMsWBsMWsWWWsW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.1202399805188179
 length = 1250
 string = "BWHMsMMsWBsMsWWWsWW>"
 
 [[bristol-s8-qps]]
+avg_score = 0.12093748152256012
 length = 1280
 string = "WWHBHHsHHHBWsWsMsH"
 
 [[bristol-s8-qps]]
-length = 1280
-string = "sWsMMBsHHHsHHsMsWsMsH"
-
-[[bristol-s8-qps]]
-length = 1280
-string = "sWsMMBHsHHHsHsMsWsMsH"
-
-[[bristol-s8-qps]]
-length = 1280
-string = "sWHsHBsHHHsHHsMsWsMsH"
-
-[[bristol-s8-qps]]
+avg_score = 0.12156248092651367
 length = 1280
 string = "sWHsHBHsHHHsHsMsWsMsH"
 
 [[bristol-s8-qps]]
+avg_score = 0.12156248092651367
 length = 1280
-string = "sWHsHBHHsHHHBHMMsH"
+string = "sWHsHBsHHHsHHsMsWsMsH"
 
 [[bristol-s8-qps]]
+avg_score = 0.12156248092651367
 length = 1280
-string = "sWsMMBHHsHHHBHMMsH"
+string = "sWsMMBHsHHHsHsMsWsMsH"
 
 [[bristol-s8-qps]]
+avg_score = 0.12156248092651367
+length = 1280
+string = "sWsMMBsHHHsHHsMsWsMsH"
+
+[[bristol-s8-qps]]
+avg_score = 0.12171872705221176
 length = 1280
 string = "WWHBHHsHHHBsHHsMsH"
 
 [[bristol-s8-qps]]
+avg_score = 0.12171872705221176
+length = 1280
+string = "sWHsHBHHsHHHBHMMsH"
+
+[[bristol-s8-qps]]
+avg_score = 0.12171872705221176
+length = 1280
+string = "sWsMMBHHsHHHBHMMsH"
+
+[[bristol-s8-qps]]
+avg_score = 0.122499980032444
 length = 1280
 string = "sWHsHBHHsHHHBWsWsMsH"
 
 [[bristol-s8-qps]]
+avg_score = 0.122499980032444
 length = 1280
 string = "sWsMMBHHsHHHBWsWsMsH"
 
 [[bristol-s8-qps]]
-length = 1280
-string = "sWsMMBHHsHHHBsHHsMsH"
-
-[[bristol-s8-qps]]
+avg_score = 0.12328122556209564
 length = 1280
 string = "sWHsHBHHsHHHBsHHsMsH"
 
 [[bristol-s8-qps]]
+avg_score = 0.12328122556209564
+length = 1280
+string = "sWsMMBHHsHHHBsHHsMsH"
+
+[[bristol-s8-qps]]
+avg_score = 0.12468747794628143
 length = 1280
 string = "WWsHBHHsHsMsWsMHsHH"
 
 [[bristol-s8-qps]]
+avg_score = 0.12562498450279236
 length = 1280
 string = "sHsWHHBHHsHHHBsHMM"
 
 [[bristol-s8-qps]]
+avg_score = 0.12703123688697815
 length = 1280
 string = "sWsMMBsHHsHsMsWsMHsHH"
 
+[[cyclic-no-calls]]
+avg_score = 0.02604166604578495
+length = 1344
+string = "#LDYSDS"
+
+[[cyclic-no-calls]]
+avg_score = 0.1443452388048172
+length = 1344
+string = "#DLSYSL"
+
 [[implicit-leadwise]]
+avg_score = 0.08074534684419632
 length = 1288
 string = "#PLLPL[-]LLPLL[-]L[-]LLP[-]LPP[-]"
 
 [[implicit-leadwise]]
+avg_score = 0.0810559093952179
 length = 1288
 string = "#PL[-]LPLL[-]PL[-]LPLL[-]LPL[-]P[-]L"
 
 [[implicit-leadwise]]
+avg_score = 0.08136646449565887
 length = 1288
 string = "#PL[-]LPLL[-]LP[-]LLPL[-]LPP[-]L[-]L[-]"
 
 [[implicit-leadwise]]
+avg_score = 0.08214285969734192
 length = 1288
 string = "#PL[-]LPLL[-]PL[-]LLPL[-]LPP[-]L[-]L[-]"
 
 [[implicit-leadwise]]
+avg_score = 0.08214286714792252
 length = 1288
 string = "#PLLPL[-]L[-]PLP[-]LP[s]LLP[s]L[-]L[-]L"
 
 [[implicit-leadwise]]
+avg_score = 0.082298144698143
 length = 1288
 string = "#PLLPL[-]LLLLP[-]L[-]LLP[-]PLP[-]"
 
 [[implicit-leadwise]]
-length = 1288
-string = "#PLLPL[-]LPP[-]L[-]LLLLL[-]PLP[-]"
-
-[[implicit-leadwise]]
-length = 1288
-string = "#PLLPL[-]LPP[-]L[-]LLP[-]PLLLL[-]"
-
-[[implicit-leadwise]]
+avg_score = 0.082298144698143
 length = 1288
 string = "#PLLPL[-]LPLLL[-]L[-]LPL[-]PLP[-]"
 
 [[implicit-leadwise]]
+avg_score = 0.082298144698143
+length = 1288
+string = "#PLLPL[-]LPP[-]L[-]LLLLL[-]PLP[-]"
+
+[[implicit-leadwise]]
+avg_score = 0.082298144698143
+length = 1288
+string = "#PLLPL[-]LPP[-]L[-]LLP[-]PLLLL[-]"
+
+[[implicit-leadwise]]
+avg_score = 0.08244048058986664
 length = 1344
 string = "#PL[-]LP[-]LLL[-]PL[-]LPLL[-]PLL[-]LP[-]"
 
 [[implicit-leadwise]]
-length = 1288
-string = "#PL[-]LPL[-]LLLP[-]LPL[-]LPL[-]P[-]L"
-
-[[implicit-leadwise]]
-length = 1288
-string = "#PL[-]LPL[-]LLPL[-]LPL[-]LPL[-]P[-]L"
-
-[[implicit-leadwise]]
-length = 1288
-string = "#PL[-]LPL[-]LPLL[-]LPL[-]LPL[-]P[-]L"
-
-[[implicit-leadwise]]
-length = 1288
-string = "#PL[-]LPL[-]PLLL[-]LPL[-]LPL[-]P[-]L"
-
-[[implicit-leadwise]]
-length = 1288
-string = "#PL[-]LPL[-]PP[-]LPL[-]LPL[-]LLL[-]L"
-
-[[implicit-leadwise]]
+avg_score = 0.08260869979858398
 length = 1288
 string = "#PL[-]LPLL[-]LP[-]LLPL[-]LPL[s]P[s]L"
 
 [[implicit-leadwise]]
+avg_score = 0.08260869979858398
+length = 1288
+string = "#PL[-]LPL[-]LLLP[-]LPL[-]LPL[-]P[-]L"
+
+[[implicit-leadwise]]
+avg_score = 0.08260869979858398
+length = 1288
+string = "#PL[-]LPL[-]LLPL[-]LPL[-]LPL[-]P[-]L"
+
+[[implicit-leadwise]]
+avg_score = 0.08260869979858398
+length = 1288
+string = "#PL[-]LPL[-]LPLL[-]LPL[-]LPL[-]P[-]L"
+
+[[implicit-leadwise]]
+avg_score = 0.08260869979858398
+length = 1288
+string = "#PL[-]LPL[-]PLLL[-]LPL[-]LPL[-]P[-]L"
+
+[[implicit-leadwise]]
+avg_score = 0.08260869979858398
+length = 1288
+string = "#PL[-]LPL[-]PP[-]LPL[-]LPL[-]LLL[-]L"
+
+[[implicit-leadwise]]
+avg_score = 0.08291926234960556
 length = 1288
 string = "#PL[-]LPLL[-]LP[-]LLPL[-]LP[-]L[-]L[-]P"
 
 [[implicit-leadwise]]
-length = 1288
-string = "#PLLPL[-]LPP[-]L[-]LLP[-]LLLLP[-]"
-
-[[implicit-leadwise]]
-length = 1288
-string = "#PLLPL[-]LPLLL[-]L[-]LLP[-]PPL[-]"
-
-[[implicit-leadwise]]
+avg_score = 0.08307453989982605
 length = 1288
 string = "#PLLLP[-]LPLLL[-]L[-]LLP[-]PLP[-]"
 
 [[implicit-leadwise]]
+avg_score = 0.08307453989982605
+length = 1288
+string = "#PLLPL[-]LPLLL[-]L[-]LLP[-]PPL[-]"
+
+[[implicit-leadwise]]
+avg_score = 0.08307453989982605
+length = 1288
+string = "#PLLPL[-]LPP[-]L[-]LLP[-]LLLLP[-]"
+
+[[implicit-leadwise]]
+avg_score = 0.08338510245084763
 length = 1288
 string = "#PL[-]LPLL[-]PL[-]LLPL[-]LPL[s]P[s]L"
 
 [[implicit-leadwise]]
-length = 1288
-string = "#PLLPL[-]L[-]PLP[-]PL[s]LPL[s]L[-]L[-]L"
-
-[[implicit-leadwise]]
+avg_score = 0.0836956575512886
 length = 1288
 string = "#PLLPL[-]L[-]LPP[-]PL[s]LLP[s]L[-]L[-]L"
 
 [[implicit-leadwise]]
+avg_score = 0.0836956575512886
+length = 1288
+string = "#PLLPL[-]L[-]PLP[-]PL[s]LPL[s]L[-]L[-]L"
+
+[[implicit-leadwise]]
+avg_score = 0.0836956575512886
 length = 1288
 string = "#PL[-]LPLL[-]PL[-]LLPL[-]LP[-]L[-]L[-]P"
 
 [[implicit-leadwise]]
+avg_score = 0.0838509351015091
 length = 1288
 string = "#PLLPL[-]LLPLL[-]L[-]LLP[-]PLP[-]"
 
 [[implicit-leadwise]]
+avg_score = 0.08462733775377274
 length = 1288
 string = "#PLLPL[-]LPLLL[-]L[-]LLP[-]LPP[-]"
 
 [[implicit-leadwise]]
+avg_score = 0.08757764846086502
 length = 1288
 string = "#PLLPL[-]L[-]PLP[-]PL[s]LLP[s]L[-]L[-]L"
 
 [[implicit-leadwise]]
+avg_score = 0.08773292601108551
 length = 1288
 string = "#PLLPL[-]LPLLL[-]L[-]LLP[-]PLP[-]"
 
 [[implicit-leadwise]]
+avg_score = 0.08804348856210709
 length = 1288
 string = "#PL[-]LPLL[-]LP[-]LLPL[-]LPL[-]P[-]L"
 
 [[implicit-leadwise]]
+avg_score = 0.08881988376379013
 length = 1288
 string = "#PL[-]LPLL[-]PL[-]LLPL[-]LPL[-]P[-]L"
 
 [[inclusive-method-count]]
+avg_score = 0.2589285671710968
 length = 224
 string = ""
 
+[[leadwise-no-calls]]
+avg_score = 0.18125000596046448
+length = 160
+string = "#SSYYY"
+
+[[leadwise-no-calls]]
+avg_score = 0.1822916716337204
+length = 192
+string = "#SYSESY"
+
+[[leadwise-no-calls]]
+avg_score = 0.1822916716337204
+length = 192
+string = "#YYSYYY"
+
+[[leadwise-no-calls]]
+avg_score = 0.1830357164144516
+length = 224
+string = "#YYYSESY"
+
+[[leadwise-no-calls]]
+avg_score = 0.1927083283662796
+length = 192
+string = "#ESSYYS"
+
+[[leadwise-no-calls]]
+avg_score = 0.1953125
+length = 128
+string = "#YSSS"
+
+[[leadwise-no-calls]]
+avg_score = 0.1964285671710968
+length = 224
+string = "#ESYYYYS"
+
+[[leadwise-no-calls]]
+avg_score = 0.1964285671710968
+length = 224
+string = "#SSSSSSS"
+
+[[leadwise-no-calls]]
+avg_score = 0.20000000298023224
+length = 160
+string = "#YSSYY"
+
+[[leadwise-no-calls]]
+avg_score = 0.20000000298023224
+length = 160
+string = "#YYYSS"
+
+[[leadwise-no-calls]]
+avg_score = 0.203125
+length = 128
+string = "#SYSS"
+
+[[leadwise-no-calls]]
+avg_score = 0.203125
+length = 192
+string = "#YYYSYY"
+
+[[leadwise-no-calls]]
+avg_score = 0.20624999701976776
+length = 160
+string = "#SYSYY"
+
+[[leadwise-no-calls]]
+avg_score = 0.2083333283662796
+length = 192
+string = "#ESYSYS"
+
+[[leadwise-no-calls]]
+avg_score = 0.2083333283662796
+length = 192
+string = "#YYSESS"
+
+[[leadwise-no-calls]]
+avg_score = 0.2098214328289032
+length = 224
+string = "#YYSESYY"
+
+[[leadwise-no-calls]]
+avg_score = 0.21250000596046448
+length = 160
+string = "#SSESS"
+
+[[leadwise-no-calls]]
+avg_score = 0.2135416716337204
+length = 192
+string = "#SSESYY"
+
+[[leadwise-no-calls]]
+avg_score = 0.2291666716337204
+length = 192
+string = "#ESYYSS"
+
+[[leadwise-no-calls]]
+avg_score = 0.2291666716337204
+length = 96
+string = "#SEE"
+
+[[leadwise-no-calls]]
+avg_score = 0.23125000298023224
+length = 160
+string = "#ESSSS"
+
+[[leadwise-no-calls]]
+avg_score = 0.2321428507566452
+length = 224
+string = "#ESYSESS"
+
+[[leadwise-no-calls]]
+avg_score = 0.234375
+length = 64
+string = "#EY"
+
+[[leadwise-no-calls]]
+avg_score = 0.2455357164144516
+length = 224
+string = "#SYSESSE"
+
+[[leadwise-no-calls]]
+avg_score = 0.2552083432674408
+length = 192
+string = "#SSYYSE"
+
+[[leadwise-no-calls]]
+avg_score = 0.26249998807907104
+length = 160
+string = "#SSSSE"
+
+[[leadwise-no-calls]]
+avg_score = 0.2723214328289032
+length = 224
+string = "#SSESYSE"
+
+[[leadwise-no-calls]]
+avg_score = 0.2760416567325592
+length = 192
+string = "#SYSYSE"
+
+[[leadwise-no-calls]]
+avg_score = 0.359375
+length = 64
+string = "#YE"
+
+[[leadwise-no-calls]]
+avg_score = 0.3645833432674408
+length = 96
+string = "#ESE"
+
 [[little-bob-shorthand]]
+avg_score = 0.5
 length = 48
 string = "LLLPL"
 
 [[little-bob-shorthand]]
+avg_score = 0.5357142686843872
 length = 56
 string = "LLLLLLL"
 
 [[little-bob-shorthand]]
+avg_score = 0.5357142686843872
 length = 112
 string = "PPPPPPP"
 
 [[little-bob-shorthand]]
+avg_score = 0.5625
 length = 48
 string = "LLLLP"
 
 [[little-bob-shorthand]]
+avg_score = 0.5833333134651184
 length = 48
 string = "LPLLL"
 
 [[little-bob-shorthand]]
+avg_score = 0.6041666865348816
 length = 48
 string = "LLPLL"
 
 [[little-bob-shorthand]]
+avg_score = 0.625
 length = 40
 string = "LPP"
 
 [[little-bob-shorthand]]
+avg_score = 0.7916666865348816
 length = 48
 string = "PLLLL"
 
 [[little-bob-shorthand]]
+avg_score = 0.800000011920929
 length = 40
 string = "PPL"
 
 [[little-bob-shorthand]]
+avg_score = 0.875
 length = 40
 string = "PLP"
 
 [[multipart]]
+avg_score = 0.3447916805744171
 length = 192
 string = "HsHH"
 
 [[multipart]]
+avg_score = 0.5375000238418579
 length = 64
 string = "sH"
 
 [[multipart-2]]
+avg_score = 0.06309523433446884
 length = 1344
 string = "sWsWH"
 
 [[multipart-2]]
+avg_score = 0.07425595074892044
 length = 1344
 string = "WHW"
 
 [[multipart-2]]
+avg_score = 0.13779762387275696
 length = 672
 string = "H"
 
 [[multipart-far-calls]]
+avg_score = 0.13625000417232513
 length = 1440
 string = "sVsVBI"
 
 [[multipart-far-calls]]
+avg_score = 0.17791666090488434
 length = 1440
 string = "VBIV"
 
 [[multipart-far-calls]]
+avg_score = 0.2241666615009308
 length = 720
 string = "BI"
 
 [[no-calls]]
+avg_score = 0.2410714328289032
 length = 224
 string = "CCCYCCC"
 
 [[no-calls]]
+avg_score = 0.2410714328289032
 length = 224
 string = "CCCYCCY"
 
 [[no-calls]]
-length = 224
-string = "YYCYCCY"
-
-[[no-calls]]
-length = 224
-string = "YYCYCCC"
-
-[[no-calls]]
+avg_score = 0.2410714328289032
 length = 224
 string = "YCCYCCC"
 
 [[no-calls]]
+avg_score = 0.2410714328289032
 length = 224
 string = "YCCYCCY"
 
 [[no-calls]]
+avg_score = 0.2410714328289032
+length = 224
+string = "YYCYCCC"
+
+[[no-calls]]
+avg_score = 0.2410714328289032
+length = 224
+string = "YYCYCCY"
+
+[[no-calls]]
+avg_score = 0.2455357164144516
 length = 224
 string = "CCCYYCC"
 
 [[no-calls]]
+avg_score = 0.2455357164144516
 length = 224
 string = "CCCYYCY"
 
 [[no-calls]]
-length = 224
-string = "YYCYYCC"
-
-[[no-calls]]
-length = 224
-string = "YYCYYCY"
-
-[[no-calls]]
-length = 224
-string = "YCCYYCC"
-
-[[no-calls]]
-length = 224
-string = "YCCYYCY"
-
-[[no-calls]]
+avg_score = 0.2455357164144516
 length = 224
 string = "CYCYYCC"
 
 [[no-calls]]
+avg_score = 0.2455357164144516
 length = 224
 string = "CYCYYCY"
 
 [[no-calls]]
+avg_score = 0.2455357164144516
+length = 224
+string = "YCCYYCC"
+
+[[no-calls]]
+avg_score = 0.2455357164144516
+length = 224
+string = "YCCYYCY"
+
+[[no-calls]]
+avg_score = 0.2455357164144516
+length = 224
+string = "YYCYYCC"
+
+[[no-calls]]
+avg_score = 0.2455357164144516
+length = 224
+string = "YYCYYCY"
+
+[[no-calls]]
+avg_score = 0.2723214328289032
 length = 224
 string = "CCCYCYC"
 
 [[no-calls]]
+avg_score = 0.2723214328289032
 length = 224
 string = "CCCYCYY"
 
 [[no-calls]]
-length = 224
-string = "YYCYCYY"
-
-[[no-calls]]
-length = 224
-string = "YYCYCYC"
-
-[[no-calls]]
-length = 224
-string = "YCCYCYC"
-
-[[no-calls]]
-length = 224
-string = "YCCYCYY"
-
-[[no-calls]]
-length = 224
-string = "CYCYCYY"
-
-[[no-calls]]
+avg_score = 0.2723214328289032
 length = 224
 string = "CYCYCYC"
 
 [[no-calls]]
+avg_score = 0.2723214328289032
+length = 224
+string = "CYCYCYY"
+
+[[no-calls]]
+avg_score = 0.2723214328289032
+length = 224
+string = "YCCYCYC"
+
+[[no-calls]]
+avg_score = 0.2723214328289032
+length = 224
+string = "YCCYCYY"
+
+[[no-calls]]
+avg_score = 0.2723214328289032
+length = 224
+string = "YYCYCYC"
+
+[[no-calls]]
+avg_score = 0.2723214328289032
+length = 224
+string = "YYCYCYY"
+
+[[no-calls]]
+avg_score = 0.2767857015132904
 length = 224
 string = "CCCYYYC"
 
 [[no-calls]]
+avg_score = 0.2767857015132904
 length = 224
 string = "CCCYYYY"
 
 [[no-calls]]
-length = 224
-string = "YYCYYYC"
-
-[[no-calls]]
-length = 224
-string = "YYCYYYY"
-
-[[no-calls]]
-length = 224
-string = "YCCYYYY"
-
-[[no-calls]]
-length = 224
-string = "YCCYYYC"
-
-[[no-calls]]
+avg_score = 0.2767857015132904
 length = 224
 string = "CYCYYYC"
 
 [[no-calls]]
+avg_score = 0.2767857015132904
 length = 224
 string = "CYCYYYY"
 
+[[no-calls]]
+avg_score = 0.2767857015132904
+length = 224
+string = "YCCYYYC"
+
+[[no-calls]]
+avg_score = 0.2767857015132904
+length = 224
+string = "YCCYYYY"
+
+[[no-calls]]
+avg_score = 0.2767857015132904
+length = 224
+string = "YYCYYYC"
+
+[[no-calls]]
+avg_score = 0.2767857015132904
+length = 224
+string = "YYCYYYY"
+
 [[no-links]]
+avg_score = 0.2589285671710968
 length = 224
 string = "BBBBBBB"
 
 [[no-links]]
+avg_score = 0.2723214328289032
 length = 224
 string = "YYYYYYY"
 
 [[non-uniform-chs]]
+avg_score = 0.08624996989965439
 length = 1280
 string = "HWHBHsMsMsHBsHBH"
 
 [[non-uniform-chs]]
+avg_score = 0.08630950003862381
 length = 1344
 string = "HHBVMMMFBH"
 
 [[non-uniform-chs]]
+avg_score = 0.0863095074892044
 length = 1344
 string = "sHBsMVsMsMFsWBsH"
 
 [[non-uniform-chs]]
+avg_score = 0.08660712093114853
 length = 1344
 string = "sHBsMVsMMFsHsWHBsH"
 
 [[non-uniform-chs]]
+avg_score = 0.08671872317790985
 length = 1280
 string = "HWHBHsHBBsMH"
 
 [[non-uniform-chs]]
+avg_score = 0.08703122287988663
 length = 1280
 string = "sHsWHBHBsWBsHMsWsH"
 
 [[non-uniform-chs]]
+avg_score = 0.08720235526561737
 length = 1344
 string = "sHsWBsHVMMMFBsH"
 
 [[non-uniform-chs]]
-length = 1280
-string = "sHBsMBsWHBWsH"
-
-[[non-uniform-chs]]
+avg_score = 0.0873437374830246
 length = 1280
 string = "sHBsMBsWBMWsH"
 
 [[non-uniform-chs]]
+avg_score = 0.0873437374830246
+length = 1280
+string = "sHBsMBsWHBWsH"
+
+[[non-uniform-chs]]
+avg_score = 0.08749998360872269
 length = 1280
 string = "sHBsHsHsMBBMsWsH"
 
 [[non-uniform-chs]]
+avg_score = 0.08749998360872269
 length = 1280
 string = "sHBsMsHBBMsWsWsH"
 
 [[non-uniform-chs]]
-length = 1280
-string = "sHsWsHBsHsMsMsHBHBsH"
-
-[[non-uniform-chs]]
+avg_score = 0.08781246840953827
 length = 1280
 string = "sHsMsMsWHBHsHBHBsH"
 
 [[non-uniform-chs]]
+avg_score = 0.08781246840953827
 length = 1280
-string = "sHsWBsMsHsHBHBsH"
+string = "sHsWsHBsHsMsMsHBHBsH"
 
 [[non-uniform-chs]]
+avg_score = 0.08828122913837433
 length = 1280
 string = "HWWHsTsVBMWH"
 
 [[non-uniform-chs]]
+avg_score = 0.08828122913837433
+length = 1280
+string = "sHsWBsMsHsHBHBsH"
+
+[[non-uniform-chs]]
+avg_score = 0.08839283883571625
 length = 1344
 string = "sHsWHHsTsFHsWsH"
 
 [[non-uniform-chs]]
+avg_score = 0.08906247466802597
 length = 1280
 string = "sHsWHsHBMBHBsH"
 
 [[non-uniform-chs]]
-length = 1280
-string = "sHBsMBsWBsHMsWsH"
-
-[[non-uniform-chs]]
+avg_score = 0.08906248211860657
 length = 1280
 string = "sHBBMWBsHHsMsH"
 
 [[non-uniform-chs]]
+avg_score = 0.08906248211860657
+length = 1280
+string = "sHBsMBsWBsHMsWsH"
+
+[[non-uniform-chs]]
+avg_score = 0.08921872824430466
 length = 1280
 string = "sHBBsHMsWBsHHsMsH"
 
 [[non-uniform-chs]]
+avg_score = 0.08958331495523453
 length = 1344
 string = "sHBsMVsMMFsHBsHMsH"
 
 [[non-uniform-chs]]
+avg_score = 0.08984372764825821
 length = 1280
 string = "sHsWBsHsMBBMsWsH"
 
 [[non-uniform-chs]]
+avg_score = 0.0899999812245369
 length = 1280
 string = "sHBsHBWsHBsHHsMsH"
 
 [[non-uniform-chs]]
+avg_score = 0.09015621989965439
 length = 1280
 string = "sHsWHBHsMsMHBsHBsH"
 
 [[non-uniform-chs]]
+avg_score = 0.09093747287988663
 length = 1280
 string = "sHsMWsHBBsHBHHsMsH"
 
 [[non-uniform-chs]]
+avg_score = 0.09107140451669693
 length = 1344
 string = "sHsWHBHsMVsMsMFBsH"
 
 [[non-uniform-chs]]
+avg_score = 0.09171871840953827
 length = 1280
 string = "sHsWHHBsHBBsHMsWsH"
 
 [[non-uniform-chs]]
+avg_score = 0.09176827222108841
 length = 1312
 string = "sHBBsHBBsHBsHHsMsH"
 
 [[non-uniform-chs]]
+avg_score = 0.09255950152873993
 length = 1344
 string = "sHBsMVsMsMFHBHsMsH"
 
 [[non-uniform-chs]]
+avg_score = 0.09328122437000275
 length = 1280
 string = "sHsWHBHsMsMsHBHBsH"
 
 [[pb-split-treble]]
+avg_score = 0.050235480070114136
 length = 1274
 string = "#P[-]P[s]P[-]P[t]PP[s]PP[t]PPP[s]P[-]P[-]"
 
 [[pb-split-treble]]
+avg_score = 0.050235480070114136
 length = 1274
 string = "#P[-]P[t]P[-]P[-]P[-]P[t]PP[-]P[s]PPPP[-]"
 
 [[pb-split-treble]]
-length = 1274
-string = "#P[t]P[-]PP[-]PPP[s]PPP[-]P[-]P[t]P[-]"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[-]PP[-]PPP[s]PPP[-]P[t]P[-]P[-]"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[-]PP[-]PPP[s]PPP[s]P[s]P[-]P[t]"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[-]PP[-]PPP[s]PPP[-]P[-]P[-]P[t]"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]PPPP[s]PP[t]P[s]P[s]PP[-]P[-]"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]PPPP[s]PP[t]P[t]P[s]PP[s]P[t]"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]PPPP[s]PP[t]P[-]P[-]PP[-]P[-]"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[-]PP[-]PPP[s]PPP[s]P[s]P[t]P[-]"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]PPP[s]P[s]PP[t]P[s]P[s]PP[s]P"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]PPP[-]P[-]PP[-]P[-]P[t]PP[s]P"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]PPP[t]P[s]PP[-]P[t]P[s]PP[s]P"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]PPP[s]P[s]PP[-]P[t]P[-]PP[s]P"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]PPP[-]P[-]PP[t]P[s]P[s]PP[s]P"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]PPP[s]P[s]PP[-]P[-]P[t]PP[s]P"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]PPP[t]P[s]PP[t]P[-]P[s]PP[s]P"
-
-[[pb-split-treble]]
+avg_score = 0.0565149150788784
 length = 1274
 string = "#PPP[t]PP[t]P[s]PP[s]PPPP[s]P[t]"
 
 [[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]PPP[-]P[-]PP[-]P[t]P[-]PP[s]P"
-
-[[pb-split-treble]]
+avg_score = 0.0565149150788784
 length = 1274
 string = "#PPP[t]P[s]P[t]PP[-]PPPP[t]P[s]P[s]"
 
 [[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]P[-]P[s]PP[-]P[s]PPPP[t]P[-]P[s]"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]PP[t]P[t]PPP[t]P[s]PP[-]PP"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[t]P[t]P[-]P[s]PP[s]P[-]PPPP[t]P[-]P[s]"
-
-[[pb-split-treble]]
+avg_score = 0.0565149150788784
 length = 1274
 string = "#P[-]P[s]PP[-]P[s]PPP[t]P[s]PP[-]PP"
 
 [[pb-split-treble]]
-length = 1274
-string = "#P[s]P[-]PP[-]P[s]PPP[t]P[s]PP[-]PP"
-
-[[pb-split-treble]]
-length = 1274
-string = "#P[-]P[s]P[-]P[-]P[-]PP[t]PPPP[-]PP"
-
-[[pb-split-treble]]
+avg_score = 0.0565149150788784
 length = 1274
 string = "#P[-]P[s]P[-]PP[s]PP[t]PPP[s]P[-]PP"
 
 [[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[-]P[s]P[-]P[-]P[-]PP[t]PPPP[-]PP"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[s]P[-]PP[-]P[s]PPP[t]P[s]PP[-]PP"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[-]PP[-]PPP[s]PPP[-]P[-]P[-]P[t]"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[-]PP[-]PPP[s]PPP[-]P[-]P[t]P[-]"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[-]PP[-]PPP[s]PPP[-]P[t]P[-]P[-]"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[-]PP[-]PPP[s]PPP[s]P[s]P[-]P[t]"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[-]PP[-]PPP[s]PPP[s]P[s]P[t]P[-]"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
 length = 1274
 string = "#P[t]P[-]P[-]PP[s]PP[t]P[s]PP[s]P[-]PP"
 
 [[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]PPPP[s]PP[t]P[-]P[-]PP[-]P[-]"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]PPPP[s]PP[t]P[s]P[s]PP[-]P[-]"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]PPPP[s]PP[t]P[t]P[s]PP[s]P[t]"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]PPP[-]P[-]PP[-]P[-]P[t]PP[s]P"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]PPP[-]P[-]PP[-]P[t]P[-]PP[s]P"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]PPP[-]P[-]PP[t]P[s]P[s]PP[s]P"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]PPP[s]P[s]PP[-]P[-]P[t]PP[s]P"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]PPP[s]P[s]PP[-]P[t]P[-]PP[s]P"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]PPP[s]P[s]PP[t]P[s]P[s]PP[s]P"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]PPP[t]P[s]PP[-]P[t]P[s]PP[s]P"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]PPP[t]P[s]PP[t]P[-]P[s]PP[s]P"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]PP[t]P[t]PPP[t]P[s]PP[-]PP"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]P[-]P[s]PP[-]P[s]PPPP[t]P[-]P[s]"
+
+[[pb-split-treble]]
+avg_score = 0.0565149150788784
+length = 1274
+string = "#P[t]P[t]P[-]P[s]PP[s]P[-]PPPP[t]P[-]P[s]"
+
+[[pb-split-treble]]
+avg_score = 0.06279435008764267
 length = 1274
 string = "#P[t]P[t]PPPP[s]PP[t]P[-]P[-]PP[s]P[s]"
 
 [[pb-split-treble]]
+avg_score = 0.06279435008764267
 length = 1274
 string = "#P[t]P[t]PPPP[s]PP[t]P[s]P[s]PP[s]P[s]"

--- a/monument/test/_results.toml
+++ b/monument/test/_results.toml
@@ -200,6 +200,126 @@ string = "sHsWHHBHHsHHHBsHMM"
 length = 1280
 string = "sWsMMBsHHsHsMsWsMHsHH"
 
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]LLPLL[-]L[-]LLP[-]LPP[-]"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPLL[-]PL[-]LPLL[-]LPL[-]P[-]L"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPLL[-]LP[-]LLPL[-]LPP[-]L[-]L[-]"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPLL[-]PL[-]LLPL[-]LPP[-]L[-]L[-]"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]L[-]PLP[-]LP[s]LLP[s]L[-]L[-]L"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]LLLLP[-]L[-]LLP[-]PLP[-]"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]LPP[-]L[-]LLLLL[-]PLP[-]"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]LPP[-]L[-]LLP[-]PLLLL[-]"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]LPLLL[-]L[-]LPL[-]PLP[-]"
+
+[[implicit-leadwise]]
+length = 1344
+string = "#PL[-]LP[-]LLL[-]PL[-]LPLL[-]PLL[-]LP[-]"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPL[-]LLLP[-]LPL[-]LPL[-]P[-]L"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPL[-]LLPL[-]LPL[-]LPL[-]P[-]L"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPL[-]LPLL[-]LPL[-]LPL[-]P[-]L"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPL[-]PLLL[-]LPL[-]LPL[-]P[-]L"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPL[-]PP[-]LPL[-]LPL[-]LLL[-]L"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPLL[-]LP[-]LLPL[-]LPL[s]P[s]L"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPLL[-]LP[-]LLPL[-]LP[-]L[-]L[-]P"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]LPP[-]L[-]LLP[-]LLLLP[-]"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]LPLLL[-]L[-]LLP[-]PPL[-]"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLLP[-]LPLLL[-]L[-]LLP[-]PLP[-]"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPLL[-]PL[-]LLPL[-]LPL[s]P[s]L"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]L[-]PLP[-]PL[s]LPL[s]L[-]L[-]L"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]L[-]LPP[-]PL[s]LLP[s]L[-]L[-]L"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPLL[-]PL[-]LLPL[-]LP[-]L[-]L[-]P"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]LLPLL[-]L[-]LLP[-]PLP[-]"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]LPLLL[-]L[-]LLP[-]LPP[-]"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]L[-]PLP[-]PL[s]LLP[s]L[-]L[-]L"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PLLPL[-]LPLLL[-]L[-]LLP[-]PLP[-]"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPLL[-]LP[-]LLPL[-]LPL[-]P[-]L"
+
+[[implicit-leadwise]]
+length = 1288
+string = "#PL[-]LPLL[-]PL[-]LLPL[-]LPL[-]P[-]L"
+
 [[inclusive-method-count]]
 length = 224
 string = ""
@@ -523,3 +643,123 @@ string = "sHBsMVsMsMFHBHsMsH"
 [[non-uniform-chs]]
 length = 1280
 string = "sHsWHBHsMsMsHBHBsH"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[-]P[s]P[-]P[t]PP[s]PP[t]PPP[s]P[-]P[-]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[-]P[t]P[-]P[-]P[-]P[t]PP[-]P[s]PPPP[-]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[-]PP[-]PPP[s]PPP[-]P[-]P[t]P[-]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[-]PP[-]PPP[s]PPP[-]P[t]P[-]P[-]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[-]PP[-]PPP[s]PPP[s]P[s]P[-]P[t]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[-]PP[-]PPP[s]PPP[-]P[-]P[-]P[t]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PPPP[s]PP[t]P[s]P[s]PP[-]P[-]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PPPP[s]PP[t]P[t]P[s]PP[s]P[t]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PPPP[s]PP[t]P[-]P[-]PP[-]P[-]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[-]PP[-]PPP[s]PPP[s]P[s]P[t]P[-]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PPP[s]P[s]PP[t]P[s]P[s]PP[s]P"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PPP[-]P[-]PP[-]P[-]P[t]PP[s]P"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PPP[t]P[s]PP[-]P[t]P[s]PP[s]P"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PPP[s]P[s]PP[-]P[t]P[-]PP[s]P"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PPP[-]P[-]PP[t]P[s]P[s]PP[s]P"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PPP[s]P[s]PP[-]P[-]P[t]PP[s]P"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PPP[t]P[s]PP[t]P[-]P[s]PP[s]P"
+
+[[pb-split-treble]]
+length = 1274
+string = "#PPP[t]PP[t]P[s]PP[s]PPPP[s]P[t]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PPP[-]P[-]PP[-]P[t]P[-]PP[s]P"
+
+[[pb-split-treble]]
+length = 1274
+string = "#PPP[t]P[s]P[t]PP[-]PPPP[t]P[s]P[s]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]P[-]P[s]PP[-]P[s]PPPP[t]P[-]P[s]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PP[t]P[t]PPP[t]P[s]PP[-]PP"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]P[-]P[s]PP[s]P[-]PPPP[t]P[-]P[s]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[-]P[s]PP[-]P[s]PPP[t]P[s]PP[-]PP"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[s]P[-]PP[-]P[s]PPP[t]P[s]PP[-]PP"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[-]P[s]P[-]P[-]P[-]PP[t]PPPP[-]PP"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[-]P[s]P[-]PP[s]PP[t]PPP[s]P[-]PP"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[-]P[-]PP[s]PP[t]P[s]PP[s]P[-]PP"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PPPP[s]PP[t]P[-]P[-]PP[s]P[s]"
+
+[[pb-split-treble]]
+length = 1274
+string = "#P[t]P[t]PPPP[s]PP[t]P[s]P[s]PP[s]P[s]"

--- a/monument/test/_results.toml
+++ b/monument/test/_results.toml
@@ -200,6 +200,10 @@ string = "sHsWHHBHHsHHHBsHMM"
 length = 1280
 string = "sWsMMBsHHsHsMsWsMHsHH"
 
+[[inclusive-method-count]]
+length = 224
+string = ""
+
 [[multipart]]
 length = 192
 string = "HsHH"

--- a/monument/test/cyclic-no-calls.toml
+++ b/monument/test/cyclic-no-calls.toml
@@ -1,0 +1,13 @@
+length = "qp"
+base_calls = "none"
+methods = [
+    { name = "Devalike", place_notation = "-58-14.58-58.36-14-58-36-78,12", stage = 8 },
+    "Lessness Surprise Major",
+    "Superlative Surprise Major",
+    "York Surprise Major",
+]
+part_head = "13456782"
+method_count = { min = 0, max = 500 }
+
+[[music]]
+run_lengths = [4, 5, 6, 7, 8]

--- a/monument/test/implicit-leadwise.toml
+++ b/monument/test/implicit-leadwise.toml
@@ -1,0 +1,4 @@
+length = "QP"
+methods = ["Plain Bob Major", "Little Bob Major"]
+part_head = "13456782"
+music_file = "music-8.toml"

--- a/monument/test/inclusive-method-count.toml
+++ b/monument/test/inclusive-method-count.toml
@@ -1,0 +1,8 @@
+# This checks that the method count is inclusive rather than half-inclusive (i.e. `method_count.max`
+# value must be possible).  If the method range is non-inclusive, then no method counts are possible
+# and thus no comps are generated.  We expect the only comp to be the plain course.
+
+length = 224
+method = "Bristol Surprise Major"
+music_file = "music-8.toml"
+method_count = { min = 224, max = 224 }

--- a/monument/test/leadwise-no-calls.toml
+++ b/monument/test/leadwise-no-calls.toml
@@ -1,0 +1,12 @@
+length = "practice"
+base_calls = "none"
+methods = [
+    { title = "Lessness Surprise Major", shorthand = "E" },
+    "Superlative Surprise Major",
+    "York Surprise Major",
+]
+leadwise = true
+method_count = { min = 0, max = 500 }
+
+[[music]]
+run_lengths = [4, 5, 6, 7, 8]

--- a/monument/test/little-bob-shorthand.toml
+++ b/monument/test/little-bob-shorthand.toml
@@ -1,0 +1,8 @@
+# Tests that Little Bob is given 'L', rather than '?' as its shorthand.  This happened because
+# Monument would use the methods _name_ rather than its _title_ to generate the shorthand (Little
+# Bob has no name, because its whole title is a classification).
+
+length = "practice"
+methods = ["Plain Bob Major", "Little Bob Major"]
+base_calls = "none"
+music_file = "music-8.toml"

--- a/monument/test/pb-split-treble.toml
+++ b/monument/test/pb-split-treble.toml
@@ -1,0 +1,15 @@
+method = "Plain Bob Triples"
+length = "QP"
+leadwise = true
+part_head = "2345671"
+
+bob_weight = 0
+single_weight = 0
+
+[[calls]]
+symbol = "t"
+place_notation = "34"
+weight = 0
+
+[[music]]
+run_lengths = [4]

--- a/monument/to-complib.py
+++ b/monument/to-complib.py
@@ -3,53 +3,99 @@
 import sys
 import re
 
+
 PASTE_TO_CLIPBOARD = True  # TODO: Make this a CLI arg
 
-callstring = sys.argv[1]
 
-# Parse the call-string
-callpairs = []  # Pairs of (call_symbol, position)
-if "[" in callstring:
-    # Parse spliced: calls are in `[`s
-    regex = re.compile(r"\[([^\[\]]*)\]")
-    # Alternate between methods and calls (starting with method
+def main():
+    callstring = sys.argv[1]
+    if callstring.startswith("#"):
+        # Convert leadwise comp to numerical notation
+        complib_string = convert_leadwise(callstring[1:])
+    else:
+        complib_string = convert_coursewise(callstring)
+
+    if PASTE_TO_CLIPBOARD:
+        import pyperclip
+
+        pyperclip.copy(complib_string)
+    else:
+        print(complib_string)
+
+
+def convert_leadwise(callstring):
+    # Parse spliced: calls are in `[`s, indexed by how many leads have been generated
     method_string = ""
+    call_indices = []
+    call_symbols = []
+    def add_call(symbol):
+        call_indices.append(str(len(method_string)))
+        call_symbols.append(symbol)
+
     is_method = True
-    for seg in regex.split(callstring):
+    for seg in re.compile(r"\[([^\[\]]*)\]").split(callstring):
         if is_method:
             method_string += seg
         else:
-            call_name = seg[:-1]
-            calling_position = seg[-1]
-            call_name = "-" if call_name == "" else call_name
-            callpairs.append((calling_position, call_name))
+            add_call(seg)
         is_method = not is_method
-    # Add the method string, under the `Methods` heading
-    callpairs.append(("Methods", method_string))
-else:
-    # Parse non-spliced: everything is a call
-    call_so_far = ""
-    for c in callstring:
-        if not c.isalpha():
-            continue
-        if c.islower():
-            call_so_far += c
-        else:
-            calling_position = c
-            call_name = "-" if call_so_far == "" else call_so_far
-            callpairs.append((calling_position, call_name))
-            call_so_far = ""
 
-# Convert to complib's layout
-columns = list(set(map(lambda v: v[0], callpairs)))
-lines = ["\t".join(columns)] + [
-    "\t" * columns.index(position) + call for (position, call) in callpairs
-]
-complib_string = "\n".join(lines)
+    # Add a ':' at the end of the comp
+    add_call(":")
 
-if PASTE_TO_CLIPBOARD:
-    import pyperclip
+    # Create a composition string like:
+    # +-----------------+----------------+---
+    # |     Methods     | <call numbers> | ...
+    # +-----------------+----------------+---
+    # | <method_string> | <call symbols> | ...
+    # +-----------------+----------------+---
+    first_line = "\t".join(["Methods"] + call_indices)
+    second_line = "\t".join([method_string] + call_symbols)
+    return first_line + "\n" + second_line
 
-    pyperclip.copy(complib_string)
-else:
-    print(complib_string)
+
+def convert_coursewise(callstring):
+    # Parse the call-string
+    callpairs = []  # Pairs of (call_symbol, position)
+    if "[" in callstring:
+        # Parse spliced: calls are in `[`s
+        regex = re.compile(r"\[([^\[\]]*)\]")
+        # Alternate between methods and calls (starting with method
+        method_string = ""
+        is_method = True
+        for seg in regex.split(callstring):
+            if is_method:
+                method_string += seg
+            else:
+                call_name = seg[:-1]
+                calling_position = seg[-1]
+                call_name = "-" if call_name == "" else call_name
+                callpairs.append((calling_position, call_name))
+            is_method = not is_method
+        # Add the method string, under the `Methods` heading
+        callpairs.append(("Methods", method_string))
+    else:
+        # Parse non-spliced: everything is a call
+        call_so_far = ""
+        for c in callstring:
+            if not c.isalpha():
+                continue
+            if c.islower():
+                call_so_far += c
+            else:
+                calling_position = c
+                call_name = "-" if call_so_far == "" else call_so_far
+                callpairs.append((calling_position, call_name))
+                call_so_far = ""
+
+    # Convert to complib's layout
+    columns = list(set(map(lambda v: v[0], callpairs)))
+    lines = ["\t".join(columns)] + [
+        "\t" * columns.index(position) + call for (position, call) in callpairs
+    ]
+    complib_string = "\n".join(lines)
+    return complib_string
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This makes Monument much easier to use for e.g. cyclic multi-parts, where no calling bells are fixed across parts and thus 'course heads' aren't well defined.