### PR TITLE
Allow `*` in masks

### DIFF
--- a/bellframe/src/stage.rs
+++ b/bellframe/src/stage.rs
@@ -98,6 +98,11 @@ impl Stage {
         (0..self.num_bells()).map(Bell::from_index)
     }
 
+    /// Returns `true` if a given [`Bell`] is contained in this `Stage`.
+    pub fn contains(self, bell: Bell) -> bool {
+        bell.number() <= self.num_bells()
+    }
+
     /// Returns true if this `Stage` denotes an even number of [`Bell`]s
     #[inline(always)]
     pub fn is_even(self) -> bool {

--- a/monument/README.md
+++ b/monument/README.md
@@ -45,7 +45,7 @@ methods = [
     "Yorkshire Surprise Major",
     { title = "Lessness Surprise Major", shorthand = "E" },
 ]
-course_heads = ["1xxxxx78", "15678xxx"]
+course_heads = ["*78", "*7856"]
 
 [[music]]
 run_lengths = [4, 5, 6, 7, 8]

--- a/monument/cli/src/lib.rs
+++ b/monument/cli/src/lib.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 use bellframe::{
+    mask::RegexToMaskError,
     place_not::{self, PnBlockParseError},
     InvalidRowError,
 };
@@ -104,6 +105,7 @@ pub enum Error {
     NoMethods,
     CcLibNotFound,
     PartHeadParse(InvalidRowError),
+    ChMaskParse(String, RegexToMaskError),
     SpecFile(PathBuf, spec::TomlReadError),
     MusicFile(PathBuf, spec::TomlReadError),
     MethodNotFound { suggestions: Vec<String> },

--- a/monument/cli/src/spec.rs
+++ b/monument/cli/src/spec.rs
@@ -33,16 +33,12 @@ const METHOD_BALANCE_ALLOWANCE: f32 = 0.1; // By how much the method balance is 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Spec {
+    /* GENERAL */
     /// The range of lengths of composition which are allowed
     length: Length,
     /// Monument won't stop until it generates the `num_comps` best compositions
     #[serde(default = "get_30")]
     num_comps: usize,
-    /// Monument won't stop until it generates the `num_comps` best compositions
-    #[serde(default)]
-    splice_style: SpliceStyle,
-    /// A [`Row`](bellframe::Row) which generates the part heads of this composition
-    part_head: Option<String>,
     /// If `true`, generate compositions lead-wise, rather than course-wise.  This is useful for
     /// cases like cyclic comps where no course heads are preserved across parts.
     ///
@@ -50,17 +46,20 @@ pub struct Spec {
     /// affects the tenor
     leadwise: Option<bool>,
 
-    /// Set to `true` to allow comps to not start at the lead head.
+    /* METHODS */
+    /// The [`Method`] who's compositions we are after
+    method: Option<MethodSpec>,
     #[serde(default)]
-    snap_start: bool,
-    /// Which indices within a lead should the composition be allowed to start.  If unspecified,
-    /// then all locations are allowed
-    #[serde(default = "default_start_indices")]
-    start_indices: Option<Vec<usize>>,
-    /// Which indices within a lead should the composition be allowed to start.  If unspecified,
-    /// then all locations are allowed
-    end_indices: Option<Vec<usize>>,
+    /// A list of [`Method`] who are being spliced together
+    methods: Vec<MethodSpec>,
+    /// At which locations method splices are allowed
+    #[serde(default)]
+    splice_style: SpliceStyle,
+    /// Bounds on how many rows of each method is allowed
+    #[serde(default)]
+    method_count: OptRange,
 
+    /* CALLS */
     /// Which calls should be used by default
     #[serde(default)] // Default to near calls
     base_calls: BaseCalls,
@@ -72,6 +71,7 @@ pub struct Spec {
     /// The weight given to each single from `base_calls`
     single_weight: Option<f32>,
 
+    /* MUSIC */
     /// Path to a file containing a music definition, relative to **this** TOML file
     music_file: Option<PathBuf>,
     /// Specification of which classes of music Monument should consider
@@ -86,6 +86,9 @@ pub struct Spec {
     /// The most consecutive rows of duffer nodes.
     max_duffer_rows: Option<usize>,
 
+    /* COURSES */
+    /// A [`Row`](bellframe::Row) which generates the part heads of this composition
+    part_head: Option<String>,
     /// If set, allows arbitrary splitting of the tenors (warning: this blows up the search size on
     /// large stages)
     #[serde(default)]
@@ -93,14 +96,17 @@ pub struct Spec {
     /// Which course heads masks are allowed (overrides `split_tenors`)
     course_heads: Option<Vec<String>>,
 
-    /// The [`Method`] who's compositions we are after
-    method: Option<MethodSpec>,
+    /* STARTS/ENDS */
+    /// Set to `true` to allow comps to not start at the lead head.
     #[serde(default)]
-    /// A list of [`Method`] who are being spliced together
-    methods: Vec<MethodSpec>,
-    /// Bounds on how many rows of each method is allowed
-    #[serde(default)]
-    method_count: OptRange,
+    snap_start: bool,
+    /// Which indices within a lead should the composition be allowed to start.  If unspecified,
+    /// then all locations are allowed
+    #[serde(default = "default_start_indices")]
+    start_indices: Option<Vec<usize>>,
+    /// Which indices within a lead should the composition be allowed to start.  If unspecified,
+    /// then all locations are allowed
+    end_indices: Option<Vec<usize>>,
 }
 
 impl Spec {

--- a/monument/examples/custom-course-heads.toml
+++ b/monument/examples/custom-course-heads.toml
@@ -1,5 +1,5 @@
 length = "peal"
 method = "Cambridge Surprise Royal"
 # Allow Monument to affect the tenors if the resulting course has 6-bell runs of 2-7
-course_heads = ["1xxxxx7890", "1234567xxx", "1674523xxx"]
+course_heads = ["*7890", "1234567xxx", "1674523xxx"]
 music_file = "music-10.toml"

--- a/monument/examples/include-8765-courses.toml
+++ b/monument/examples/include-8765-courses.toml
@@ -3,5 +3,5 @@ methods = [
     "Yorkshire Surprise Major",
     { title = "Lessness Surprise Major", shorthand = "E" },
 ]
-course_heads = ["1xxxxx78", "15678xxx"]
+course_heads = ["*78", "*7856"]
 music_file = "music-8.toml"

--- a/monument/test/multipart-2.toml
+++ b/monument/test/multipart-2.toml
@@ -2,4 +2,4 @@ length = { min = 0, max = 2000 }
 method = "Yorkshire Surprise Major"
 music_file = "../examples/music-8.toml"
 part_head = "1423"
-course_heads = ["xxxxx678"]
+course_heads = ["*678"]

--- a/monument/test/non-uniform-chs.toml
+++ b/monument/test/non-uniform-chs.toml
@@ -4,5 +4,5 @@
 
 length = "QP"
 method = "Yorkshire Surprise Major"
-course_heads = ["1xxxxx78", "15678xxx"]
+course_heads = ["*78", "*7856"]
 music_file = "music-8.toml"


### PR DESCRIPTION
Now, `course_heads = ["xxxxxx7890"]` becomes `course_heads = ["*7890"]`.  Much nicer.