### PR TITLE
Allow CHs to set per-method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## (unreleased)
+
+### Monument
+
+- (#21) Allow course-head masks to be specified per-method

--- a/monument/cli/src/lib.rs
+++ b/monument/cli/src/lib.rs
@@ -3,6 +3,9 @@
 //! shared between the various integration test runners, making sure that the integration tests run
 //! in exactly the same way as Monument itself.
 
+#![deny(clippy::all)]
+#![deny(rustdoc::broken_intra_doc_links)]
+
 pub mod calls;
 pub mod spec;
 

--- a/monument/test/_results.toml
+++ b/monument/test/_results.toml
@@ -1314,3 +1314,23 @@ string = "#P[t]P[t]PPPP[s]PP[t]P[-]P[-]PP[s]P[s]"
 avg_score = 0.06279435008764267
 length = 1274
 string = "#P[t]P[t]PPPP[s]PP[t]P[s]P[s]PP[s]P[s]"
+
+[[per-method-chs]]
+avg_score = -0.01796874962747097
+length = 256
+string = "B[sH]YYYYYYY[sH]"
+
+[[per-method-chs]]
+avg_score = -0.014137931168079376
+length = 290
+string = "BY[W]YYYYYYY[sW]Y>"
+
+[[per-method-chs]]
+avg_score = 0.0
+length = 224
+string = "BBBBBBB"
+
+[[per-method-chs]]
+avg_score = 0.0
+length = 224
+string = "YYYYYYY"

--- a/monument/test/per-method-chs.toml
+++ b/monument/test/per-method-chs.toml
@@ -1,0 +1,6 @@
+length = "practice"
+methods = [
+    "Yorkshire Surprise Major",
+    { title = "Bristol Surprise Major", course_heads = ["12345678"] }
+]
+method_count = { min = 0, max = 400 }


### PR DESCRIPTION
Methods can now be given custom CHs by adding a `course_heads` parameter to their definition.  For example:

```toml
length = "practice"
methods = [
    "Yorkshire Surprise Major",
    { title = "Bristol Surprise Major", course_heads = ["12345678"] }
]
method_count = { min = 0, max = 400 }
```
would generate practice-night touches where Bristol only appears in the plain course.  This is more useful for cases like splicing principles with treble-hunting methods, because you can make sure that the treble-hunting methods only use the true treble as a hunt bell:

```toml
methods = [
    "Rapid Wrap Major",
    { title = "Bristol Surprise Major", course_heads = ["1*"] }
]
```