### PR TITLE
Add CI workflow for creating release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,78 +1,135 @@
-name: Release
+# This workflow is based on that of ripgrep:
+#   https://github.com/BurntSushi/ripgrep/blob/0b36942f680bfa9ae88a564f2636aa8286470073/.github/workflows/release.yml
 
+# The way this works is the following:
+#
+# The create-release job runs purely to initialize the GitHub release itself
+# and to output upload_url for the following job.
+#
+# The build-release job runs only once create-release is finished. It gets the
+# release upload URL from create-release job outputs, then builds the release
+# executables for each supported platform and attaches them as release assets
+# to the previously created release.
+#
+# The key here is that we create the release only once.
+#
+# Reference:
+# https://eugene-babichenko.github.io/blog/2020/05/09/github-actions-cross-platform-auto-releases/
+
+name: release
 on:
-  release:
-    types: [created]
-
+  push:
+    # Enable when testing release infrastructure on a branch.
+    # branches:
+    # - release-workflow
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+"
 jobs:
-  build:
+  create-release:
+    name: create-release
     runs-on: ubuntu-latest
-
+    # env:
+      # Set to force version number, e.g., when no tag exists.
+      # MONUMENT_VERSION: TEST-0.0.0
+    outputs:
+      upload_url: ${{ steps.release.outputs.upload_url }}
+      monument_version: ${{ env.MONUMENT_VERSION }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Build
+      - name: Get the release version from the tag
+        shell: bash
+        if: env.MONUMENT_VERSION == ''
         run: |
-          cargo build --all --release
-          strip target/release/monument_cli
-          mv target/release/monument_cli monument_cli_amd64
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: monument_cli_amd64
+          # Apparently, this is the right way to get a tag name. Really?
+          #
+          # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
+          echo "MONUMENT_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "version is: ${{ env.MONUMENT_VERSION }}"
+      - name: Create GitHub release
+        id: release
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
-  build-win:
-    runs-on: windows-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
-          default: true
-          override: true
+          tag_name: ${{ env.MONUMENT_VERSION }}
+          release_name: ${{ env.MONUMENT_VERSION }}
 
-      - name: Build
-        run: cargo build --all --release
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: target/release/monument_cli.exe
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  build-mac:
-    runs-on: macos-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+  build-release:
+    name: build-release
+    needs: ['create-release']
+    runs-on: ${{ matrix.os }}
+    env:
+      # Emit backtraces on panics.
+      RUST_BACKTRACE: 1
+    strategy:
+      matrix:
+        build: [linux, macos, windows-64, windows-32]
+        include:
+        - build: linux
+          os: ubuntu-18.04
+          target: x86_64-unknown-linux-musl
+        - build: macos
+          os: macos-latest
           target: x86_64-apple-darwin
-          default: true
-          override: true
+        - build: windows-64
+          os: windows-2019
+          target: x86_64-pc-windows-msvc
+        - build: windows-32
+          os: windows-2019
+          target: i686-pc-windows-msvc
 
-      - name: Build for mac
-        run: |
-          cargo build --all --release
-          strip target/release/monument_cli
-          mv target/release/monument_cli monument_cli_darwin
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: monument_darwin
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#     - name: Install packages (Ubuntu)
+#       if: matrix.os == 'ubuntu-18.04'
+#       run: sudo apt install libssl-dev
+
+#    - name: Install packages (macOS)
+#      if: matrix.os == 'macos-latest'
+#      run: |
+#        ci/macos-install-packages
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+        target: ${{ matrix.target }}
+
+    - name: Build release binary
+      run: cargo build --verbose --release
+
+    - name: Strip release binary (linux and macos)
+      if: matrix.build == 'linux' || matrix.build == 'macos'
+      run: |
+        strip "target/release/monument_cli"
+
+    - name: Build archive
+      shell: bash
+      run: |
+        staging="monument-${{ needs.create-release.outputs.monument_version }}-${{ matrix.build }}"
+        mkdir -p "$staging"
+
+        cp {LICENSE,monument/README.md} "$staging/"
+
+        if [ "${{ matrix.os }}" = "windows-2019" ]; then
+          cp "target/release/monument_cli.exe" "$staging/monument.exe"
+          7z a "$staging.zip" "$staging"
+          echo "ASSET=$staging.zip" >> $GITHUB_ENV
+        else
+          cp "target/release/monument_cli" "$staging/monument"
+          tar czf "$staging.tar.gz" "$staging"
+          echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
+        fi
+
+    - name: Upload release archive
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create-release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET }}
+        asset_name: ${{ env.ASSET }}
+        asset_content_type: application/octet-stream


### PR DESCRIPTION
This should stop people from going through the hassle of installing Rust in order to get a working build of Monument.