### PR TITLE
Fix off-by-one in part heads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - (#17, #24) Add a guide for the TOML input format (#24 fixes a mistake in the example)
 - (#21) Allow course-head masks to be specified per-method
 - (#24) Add `examples/` and `to-complib.py` to the pre-built releases.
+- (#25) Fix off-by-one error when outputting part heads of multi-part compositions
 
 ### BellFrame
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,8 @@
 - (#17, #24) Add a guide for the TOML input format (#24 fixes a mistake in the example)
 - (#21) Allow course-head masks to be specified per-method
 - (#24) Add `examples/` and `to-complib.py` to the pre-built releases.
+
+### BellFrame
+
+- (#25) Add `Row::order`, along with `RowAccumulator::accumulate_unchecked` and
+    `RowAccumulator::pre_accumulate_unchecked`.

--- a/bellframe/src/row/accumulator.rs
+++ b/bellframe/src/row/accumulator.rs
@@ -34,12 +34,34 @@ impl RowAccumulator {
         Ok(())
     }
 
+    /// Performs `self = self * row`, without checking that the stages match.
+    ///
+    /// # Safety
+    ///
+    /// This is safe if `row.stage() == self.stage()`.
+    #[inline]
+    pub unsafe fn accumulate_unchecked(&mut self, row: &Row) {
+        self.total.mul_into_unchecked(row, &mut self.temp_row); // Multiply `total` into `temp_row`
+        std::mem::swap(&mut self.total, &mut self.temp_row); // Swap the result back into `total`
+    }
+
     /// Performs `self = row * self`
     #[inline]
     pub fn pre_accumulate(&mut self, row: &Row) -> Result<(), IncompatibleStages> {
         row.mul_into(&self.total, &mut self.temp_row)?; // Multiply `total` into `temp_row`
         std::mem::swap(&mut self.total, &mut self.temp_row); // Swap the result back into `total`
         Ok(())
+    }
+
+    /// Performs `self = row * self`, without checking that the stages match.
+    ///
+    /// # Safety
+    ///
+    /// This is safe if `row.stage() == self.stage()`.
+    #[inline]
+    pub unsafe fn pre_accumulate_unchecked(&mut self, row: &Row) {
+        row.mul_into_unchecked(&self.total, &mut self.temp_row); // Multiply `total` into `temp_row`
+        std::mem::swap(&mut self.total, &mut self.temp_row); // Swap the result back into `total`
     }
 
     /// Sets the accumulated value of `self`

--- a/bellframe/src/row/owned.rs
+++ b/bellframe/src/row/owned.rs
@@ -580,49 +580,6 @@ mod tests {
         check("14567892", Stage::CATERS, '3');
     }
 
-    #[test]
-    fn is_group() {
-        fn check(rows: &[&str]) {
-            let rows: Vec<RowBuf> = rows.iter().map(|s| RowBuf::parse(s).unwrap()).collect();
-            println!("Is {:?} a group?", rows);
-            assert!(Row::is_group(rows.iter().map(|r| r.deref())).unwrap());
-        }
-
-        check(&["1234", "1342", "1423"]);
-        check(&["1"]);
-        check(&["1234", "1324"]);
-        check(&["1234", "1234", "1234", "1324"]);
-        check(&["1234", "4123", "3412", "2341"]);
-        check(&["123456", "134256", "142356", "132456", "124356", "143256"]);
-        #[rustfmt::skip]
-        check(&[
-            "123456", "134562", "145623", "156234", "162345",
-            "165432", "126543", "132654", "143265", "154326",
-        ]);
-        check(&["123456", "234561", "345612", "456123", "561234", "612345"]);
-        #[rustfmt::skip]
-        check(&[
-            "123456", "234561", "345612", "456123", "561234", "612345",
-            "654321", "165432", "216543", "321654", "432165", "543216",
-        ]);
-    }
-
-    #[test]
-    fn is_non_group() {
-        fn check(groups: &[&str]) {
-            let rows: Vec<RowBuf> = groups.iter().map(|s| RowBuf::parse(s).unwrap()).collect();
-            println!("Is {:?} not a group?", groups);
-            assert!(!Row::is_group(rows.iter().map(|r| r.deref())).unwrap());
-        }
-
-        check(&["21"]);
-        check(&["123456", "134256", "142356", "132456", "124356"]); // 143256 is missing
-        check(&[]); // The empty set doesn't contain an identity element
-        check(&[
-            "123456", "134256", "142356", "132456", "124356", "143256", "213456",
-        ]);
-    }
-
     #[quickcheck]
     fn parse_doesnt_panic(v: String) -> bool {
         let _ = v.parse::<RowBuf>();

--- a/monument/lib/src/lib.rs
+++ b/monument/lib/src/lib.rs
@@ -53,6 +53,10 @@ impl Query {
     pub fn is_multipart(&self) -> bool {
         !self.part_head.is_rounds()
     }
+
+    pub fn num_parts(&self) -> usize {
+        self.part_head.order()
+    }
 }
 
 /// Configuration parameters for Monument which **don't** change which compositions are emitted.
@@ -122,6 +126,10 @@ impl Comp {
         s
     }
 
+    pub fn part_head(&self) -> RowBuf {
+        self.query.part_head.pow_u(self.rotation as usize)
+    }
+
     pub fn long_string(&self) -> String {
         let mut s = format!("len: {}, ", self.length,);
         // Method counts for spliced
@@ -130,9 +138,8 @@ impl Comp {
         }
         // Part heads if multi-part with >2 parts (2-part compositions only have one possible part
         // head)
-        let part_heads = self.query.part_head.closure();
-        if part_heads.len() > 2 {
-            write!(s, "PH: {}, ", &part_heads[self.rotation as usize]).unwrap();
+        if self.query.num_parts() > 2 {
+            write!(s, "PH: {}, ", self.part_head()).unwrap();
         }
         write!(
             s,

--- a/monument/test/_results.toml
+++ b/monument/test/_results.toml
@@ -293,11 +293,13 @@ string = "sWsMMBsHHsHsMsWsMHsHH"
 [[cyclic-no-calls]]
 avg_score = 0.02604166604578495
 length = 1344
+part_head = "14567823"
 string = "#LDYSDS"
 
 [[cyclic-no-calls]]
 avg_score = 0.1443452388048172
 length = 1344
+part_head = "18234567"
 string = "#DLSYSL"
 
 [[false]]
@@ -603,151 +605,181 @@ string = "HHH"
 [[implicit-leadwise]]
 avg_score = 0.08074534684419632
 length = 1288
+part_head = "14567823"
 string = "#PLLPL[-]LLPLL[-]L[-]LLP[-]LPP[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.0810559093952179
 length = 1288
+part_head = "16782345"
 string = "#PL[-]LPLL[-]PL[-]LPLL[-]LPL[-]P[-]L"
 
 [[implicit-leadwise]]
 avg_score = 0.08136646449565887
 length = 1288
+part_head = "18234567"
 string = "#PL[-]LPLL[-]LP[-]LLPL[-]LPP[-]L[-]L[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.08214285969734192
 length = 1288
+part_head = "18234567"
 string = "#PL[-]LPLL[-]PL[-]LLPL[-]LPP[-]L[-]L[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.08214286714792252
 length = 1288
+part_head = "15678234"
 string = "#PLLPL[-]L[-]PLP[-]LP[s]LLP[s]L[-]L[-]L"
 
 [[implicit-leadwise]]
 avg_score = 0.082298144698143
 length = 1288
+part_head = "14567823"
 string = "#PLLPL[-]LLLLP[-]L[-]LLP[-]PLP[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.082298144698143
 length = 1288
+part_head = "14567823"
 string = "#PLLPL[-]LPLLL[-]L[-]LPL[-]PLP[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.082298144698143
 length = 1288
+part_head = "14567823"
 string = "#PLLPL[-]LPP[-]L[-]LLLLL[-]PLP[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.082298144698143
 length = 1288
+part_head = "14567823"
 string = "#PLLPL[-]LPP[-]L[-]LLP[-]PLLLL[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.08244048058986664
 length = 1344
+part_head = "15678234"
 string = "#PL[-]LP[-]LLL[-]PL[-]LPLL[-]PLL[-]LP[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.08260869979858398
 length = 1288
+part_head = "16782345"
 string = "#PL[-]LPLL[-]LP[-]LLPL[-]LPL[s]P[s]L"
 
 [[implicit-leadwise]]
 avg_score = 0.08260869979858398
 length = 1288
+part_head = "14567823"
 string = "#PL[-]LPL[-]LLLP[-]LPL[-]LPL[-]P[-]L"
 
 [[implicit-leadwise]]
 avg_score = 0.08260869979858398
 length = 1288
+part_head = "14567823"
 string = "#PL[-]LPL[-]LLPL[-]LPL[-]LPL[-]P[-]L"
 
 [[implicit-leadwise]]
 avg_score = 0.08260869979858398
 length = 1288
+part_head = "14567823"
 string = "#PL[-]LPL[-]LPLL[-]LPL[-]LPL[-]P[-]L"
 
 [[implicit-leadwise]]
 avg_score = 0.08260869979858398
 length = 1288
+part_head = "14567823"
 string = "#PL[-]LPL[-]PLLL[-]LPL[-]LPL[-]P[-]L"
 
 [[implicit-leadwise]]
 avg_score = 0.08260869979858398
 length = 1288
+part_head = "14567823"
 string = "#PL[-]LPL[-]PP[-]LPL[-]LPL[-]LLL[-]L"
 
 [[implicit-leadwise]]
 avg_score = 0.08291926234960556
 length = 1288
+part_head = "18234567"
 string = "#PL[-]LPLL[-]LP[-]LLPL[-]LP[-]L[-]L[-]P"
 
 [[implicit-leadwise]]
 avg_score = 0.08307453989982605
 length = 1288
+part_head = "14567823"
 string = "#PLLLP[-]LPLLL[-]L[-]LLP[-]PLP[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.08307453989982605
 length = 1288
+part_head = "14567823"
 string = "#PLLPL[-]LPLLL[-]L[-]LLP[-]PPL[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.08307453989982605
 length = 1288
+part_head = "14567823"
 string = "#PLLPL[-]LPP[-]L[-]LLP[-]LLLLP[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.08338510245084763
 length = 1288
+part_head = "16782345"
 string = "#PL[-]LPLL[-]PL[-]LLPL[-]LPL[s]P[s]L"
 
 [[implicit-leadwise]]
 avg_score = 0.0836956575512886
 length = 1288
+part_head = "15678234"
 string = "#PLLPL[-]L[-]LPP[-]PL[s]LLP[s]L[-]L[-]L"
 
 [[implicit-leadwise]]
 avg_score = 0.0836956575512886
 length = 1288
+part_head = "15678234"
 string = "#PLLPL[-]L[-]PLP[-]PL[s]LPL[s]L[-]L[-]L"
 
 [[implicit-leadwise]]
 avg_score = 0.0836956575512886
 length = 1288
+part_head = "18234567"
 string = "#PL[-]LPLL[-]PL[-]LLPL[-]LP[-]L[-]L[-]P"
 
 [[implicit-leadwise]]
 avg_score = 0.0838509351015091
 length = 1288
+part_head = "14567823"
 string = "#PLLPL[-]LLPLL[-]L[-]LLP[-]PLP[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.08462733775377274
 length = 1288
+part_head = "14567823"
 string = "#PLLPL[-]LPLLL[-]L[-]LLP[-]LPP[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.08757764846086502
 length = 1288
+part_head = "15678234"
 string = "#PLLPL[-]L[-]PLP[-]PL[s]LLP[s]L[-]L[-]L"
 
 [[implicit-leadwise]]
 avg_score = 0.08773292601108551
 length = 1288
+part_head = "14567823"
 string = "#PLLPL[-]LPLLL[-]L[-]LLP[-]PLP[-]"
 
 [[implicit-leadwise]]
 avg_score = 0.08804348856210709
 length = 1288
+part_head = "16782345"
 string = "#PL[-]LPLL[-]LP[-]LLPL[-]LPL[-]P[-]L"
 
 [[implicit-leadwise]]
 avg_score = 0.08881988376379013
 length = 1288
+part_head = "16782345"
 string = "#PL[-]LPLL[-]PL[-]LLPL[-]LPL[-]P[-]L"
 
 [[inclusive-method-count]]
@@ -958,41 +990,49 @@ string = "PLP"
 [[multipart]]
 avg_score = 0.3447916805744171
 length = 192
+part_head = "12435678"
 string = "HsHH"
 
 [[multipart]]
 avg_score = 0.5375000238418579
 length = 64
+part_head = "12435678"
 string = "sH"
 
 [[multipart-2]]
 avg_score = 0.06309523433446884
 length = 1344
+part_head = "14235678"
 string = "sWsWH"
 
 [[multipart-2]]
 avg_score = 0.07425595074892044
 length = 1344
+part_head = "13425678"
 string = "WHW"
 
 [[multipart-2]]
 avg_score = 0.13779762387275696
 length = 672
+part_head = "14235678"
 string = "H"
 
 [[multipart-far-calls]]
 avg_score = 0.13625000417232513
 length = 1440
+part_head = "1452367890"
 string = "sVsVBI"
 
 [[multipart-far-calls]]
 avg_score = 0.17791666090488434
 length = 1440
+part_head = "1452367890"
 string = "VBIV"
 
 [[multipart-far-calls]]
 avg_score = 0.2241666615009308
 length = 720
+part_head = "1452367890"
 string = "BI"
 
 [[no-87s-at-back]]
@@ -1318,151 +1358,181 @@ string = "sHsWHBHsMsMsHBHBsH"
 [[pb-split-treble]]
 avg_score = 0.050235480070114136
 length = 1274
+part_head = "6712345"
 string = "#P[-]P[s]P[-]P[t]PP[s]PP[t]PPP[s]P[-]P[-]"
 
 [[pb-split-treble]]
 avg_score = 0.050235480070114136
 length = 1274
+part_head = "2345671"
 string = "#P[-]P[t]P[-]P[-]P[-]P[t]PP[-]P[s]PPPP[-]"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#PPP[t]PP[t]P[s]PP[s]PPPP[s]P[t]"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "7123456"
 string = "#PPP[t]P[s]P[t]PP[-]PPPP[t]P[s]P[s]"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[-]P[s]PP[-]P[s]PPP[t]P[s]PP[-]PP"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "7123456"
 string = "#P[-]P[s]P[-]PP[s]PP[t]PPP[s]P[-]PP"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "7123456"
 string = "#P[-]P[s]P[-]P[-]P[-]PP[t]PPPP[-]PP"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[s]P[-]PP[-]P[s]PPP[t]P[s]PP[-]PP"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "2345671"
 string = "#P[t]P[-]PP[-]PPP[s]PPP[-]P[-]P[-]P[t]"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "2345671"
 string = "#P[t]P[-]PP[-]PPP[s]PPP[-]P[-]P[t]P[-]"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "2345671"
 string = "#P[t]P[-]PP[-]PPP[s]PPP[-]P[t]P[-]P[-]"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "2345671"
 string = "#P[t]P[-]PP[-]PPP[s]PPP[s]P[s]P[-]P[t]"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "2345671"
 string = "#P[t]P[-]PP[-]PPP[s]PPP[s]P[s]P[t]P[-]"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "7123456"
 string = "#P[t]P[-]P[-]PP[s]PP[t]P[s]PP[s]P[-]PP"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PPPP[s]PP[t]P[-]P[-]PP[-]P[-]"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PPPP[s]PP[t]P[s]P[s]PP[-]P[-]"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PPPP[s]PP[t]P[t]P[s]PP[s]P[t]"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PPP[-]P[-]PP[-]P[-]P[t]PP[s]P"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PPP[-]P[-]PP[-]P[t]P[-]PP[s]P"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PPP[-]P[-]PP[t]P[s]P[s]PP[s]P"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PPP[s]P[s]PP[-]P[-]P[t]PP[s]P"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PPP[s]P[s]PP[-]P[t]P[-]PP[s]P"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PPP[s]P[s]PP[t]P[s]P[s]PP[s]P"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PPP[t]P[s]PP[-]P[t]P[s]PP[s]P"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PPP[t]P[s]PP[t]P[-]P[s]PP[s]P"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PP[t]P[t]PPP[t]P[s]PP[-]PP"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "7123456"
 string = "#P[t]P[t]P[-]P[s]PP[-]P[s]PPPP[t]P[-]P[s]"
 
 [[pb-split-treble]]
 avg_score = 0.0565149150788784
 length = 1274
+part_head = "7123456"
 string = "#P[t]P[t]P[-]P[s]PP[s]P[-]PPPP[t]P[-]P[s]"
 
 [[pb-split-treble]]
 avg_score = 0.06279435008764267
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PPPP[s]PP[t]P[-]P[-]PP[s]P[s]"
 
 [[pb-split-treble]]
 avg_score = 0.06279435008764267
 length = 1274
+part_head = "3456712"
 string = "#P[t]P[t]PPPP[s]PP[t]P[s]P[s]PP[s]P[s]"
 
 [[per-method-chs]]


### PR DESCRIPTION
Previously, we'd see output like:
```
len: 1344, ms: [224, 672, 448], PH: 12345678, score:  84.00, avg: 0.062500, str: #D[-]B[s]DD[-]NN[-]NN[s]
len: 1344, ms: [672, 448, 224], PH: 12345678, score:  85.00, avg: 0.063244, str: #B[s]D[s]BBD[-]NN[-]
len: 1344, ms: [224, 448, 672], PH: 13456782, score:  88.00, avg: 0.065476, str: #NNNN[-]NN[s]DBD[s]
len: 1344, ms: [224, 448, 672], PH: 13456782, score: 103.00, avg: 0.076637, str: #NNNN[-]NN[s]BDD[s]
```
Clearly a part-head of `12345678` isn't possible, and upon checking with CompLib the part-head was in fact `13456782`.  This PR fixes this, so the `PH: xxxx` is now correct.